### PR TITLE
Fix escaping of model-backed form with fields_for

### DIFF
--- a/lib/cell/erb/template.rb
+++ b/lib/cell/erb/template.rb
@@ -22,7 +22,7 @@ module Cell
     # this is capture copied from AV:::CaptureHelper without doing escaping.
     def capture(*args)
       value = nil
-      buffer = with_output_buffer { value = yield(*args) }
+      buffer = with_output_buffer { value = yield(*args).html_safe }
 
       return buffer.to_s if buffer.size > 0
       value # this applies for "Beachparty" string-only statements.


### PR DESCRIPTION
in response to:
https://github.com/trailblazer/cells-erb/issues/2
