### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/cells-erb.gemspec
+++ b/cells-erb.gemspec
@@ -13,6 +13,12 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/trailblazer/cells-erb'
   spec.license       = 'MIT'
 
+  spec.metadata['bug_tracker_uri'] = "#{spec.homepage}/issues"
+  spec.metadata['changelog_uri'] = "#{spec.homepage}/blob/HEAD/CHANGES.md"
+  spec.metadata['documentation_uri'] = "https://www.rubydoc.info/gems/cells-erb/#{spec.version}"
+  spec.metadata['homepage_uri'] = spec.homepage
+  spec.metadata['source_code_uri'] = spec.homepage
+
   spec.files         = `git ls-files -z`.split("\x0")
   spec.test_files    = spec.files.grep(%r{^(test)/})
   spec.require_paths = ['lib']


### PR DESCRIPTION
### Proposed Change

Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `homepage_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/cells-erb), via the Rubygems API, and the `gem` and `bundle` command-line tools, after the next release.