### PR TITLE
Remove development and test files from the gem package

### DIFF
--- a/cells-erb.gemspec
+++ b/cells-erb.gemspec
@@ -19,8 +19,11 @@ Gem::Specification.new do |spec|
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = spec.homepage
 
-  spec.files         = `git ls-files -z`.split("\x0")
-  spec.test_files    = spec.files.grep(%r{^(test)/})
+  spec.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").reject do |file|
+      file.start_with?(*%w[.git .travis Gemfile Rakefile test])
+    end
+  end
   spec.require_paths = ['lib']
 
   spec.add_dependency "cells", "~> 4.0"


### PR DESCRIPTION
There are a bunch of files in the gem package that aren't useful for downstream projects. Removing these reduces the gem package size from 8.5K to 7.5K.

```diff
< .github/workflows/ci.yml
< .github/workflows/ci_jruby.yml
< .github/workflows/ci_legacy.yml
< .github/workflows/ci_truffleruby.yml
< .gitignore
< .travis.yml
  CHANGES.md
< Gemfile
  LICENSE.txt
  README.md
< Rakefile
  cells-erb.gemspec
  lib/cell/erb.rb
  lib/cell/erb/template.rb
  lib/cell/erb/version.rb
  lib/cells-erb.rb
< test/cells/song/render_in_render.erb
< test/cells/song/render_in_render_2.erb
< test/cells/song_cell.rb
< test/erb_test.rb
< test/test_helper.rb
```